### PR TITLE
[TUR-19425]: Update buildpack to run yarn build:apps

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,10 +5,14 @@
 set -e
 
 BUILD_DIR=$1
+CACHE_DIR=$2
 ENV_DIR=$3
-
 ROOT_DIR=$(pwd)
 
+cd $CACHE_DIR
+ls
+
+cd $ROOT_DIR
 echo "-----> ⌛️  Building apps..."
 
 cd $BUILD_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -10,18 +10,6 @@ ENV_DIR=$3
 ROOT_DIR=$(pwd)
 
 
-echo "-----> ⌛️  Building apps..."
-
-ENV_SKIP_NODE_MODULES_CHECK=$(test -f "$ENV_DIR/SKIP_NODE_MODULES_CHECK" && cat "$ENV_DIR/SKIP_NODE_MODULES_CHECK" || echo "")
-echo "SKIP_NODE_MODULES_CHECK=$ENV_SKIP_NODE_MODULES_CHECK"
-
-cd $BUILD_DIR
-yarn install --frozen-lockfile
-yarn build:apps
-cd $ROOT_DIR
-
-echo "-----> ✅  Apps built successfully"
-
 # Get env variables
 ENV_ROLE_ARN=$(test -f "$ENV_DIR/ROLE_ARN" && cat "$ENV_DIR/ROLE_ARN" || echo "")
 ENV_S3_BUCKET_NAME=$(test -f "$ENV_DIR/S3_BUCKET_NAME" && cat "$ENV_DIR/S3_BUCKET_NAME" || echo "")
@@ -115,3 +103,9 @@ echo "-----> ⌛️  Invalidating cache"
 aws cloudfront create-invalidation --distribution-id $ENV_DISTRIBUTION_ID --paths "/vite/manifest.json" "/vite/manifest-assets.json" --no-cli-pager
 
 echo "-----> ✅  Invalidated cache successfully"
+
+echo "-----> ⌛️  Prune FE source code"
+
+rm -rf "$BUILD_DIR/frontend" "$BUILD_DIR/packages" "$BUILD_DIR/app/javascript"
+
+echo "-----> ✅  Prune FE source code successfully"

--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,8 @@ ROOT_DIR=$(pwd)
 
 echo "-----> ⌛️  Building apps..."
 
+echo "$ENV_DIR/SKIP_NODE_MODULES_CHECK"
+
 cd $BUILD_DIR
 exec yarn build:apps
 cd $ROOT_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -83,3 +83,19 @@ else
   [ -z "$ENV_HEROKU_RELEASE_VERSION" ] && echo "HEROKU_RELEASE_VERSION is not set"
 fi
 
+echo "-----> ⌛️  Cleaning up slug"
+
+rm -rf "$BUILD_DIR/node_modules" \
+  "$BUILD_DIR/plop" \
+  "$BUILD_DIR/frontend" \
+  "$BUILD_DIR/packages" \
+  "$BUILD_DIR/app/javascript" \
+  "$BUILD_DIR/.awscli" \
+  "$BUILD_DIR/.heroku/node" \
+  "$BUILD_DIR/.husky" \
+  "$BUILD_DIR/.turbo" \
+  "$BUILD_DIR/.vscode"
+
+echo "-----> ✅  Cleaning up slug successfully"
+
+

--- a/bin/compile
+++ b/bin/compile
@@ -83,10 +83,3 @@ else
   [ -z "$ENV_HEROKU_RELEASE_VERSION" ] && echo "HEROKU_RELEASE_VERSION is not set"
 fi
 
-echo "-----> ⌛️  Cleaning up slug"
-
-cd "$BUILD_DIR"
-yarn clean
-rm -rf frontend packages app/javascript .awscli
-
-echo "-----> ✅  Cleaning up slug successfully"

--- a/bin/compile
+++ b/bin/compile
@@ -16,7 +16,8 @@ ENV_SKIP_NODE_MODULES_CHECK=$(test -f "$ENV_DIR/SKIP_NODE_MODULES_CHECK" && cat 
 echo "SKIP_NODE_MODULES_CHECK=$ENV_SKIP_NODE_MODULES_CHECK"
 
 cd $BUILD_DIR
-exec yarn build:apps
+yarn install --frozen-lockfile
+yarn build:apps
 cd $ROOT_DIR
 
 echo "-----> ✅  Apps built successfully"

--- a/bin/compile
+++ b/bin/compile
@@ -29,6 +29,7 @@ echo "-----> ✅  Frontend built successfully"
 if [ -n "$ENV_ROLE_ARN" ] && [ -n "$ENV_S3_BUCKET_NAME" ] && [ -n "$ENV_DISTRIBUTION_ID" ] && \
    [ -n "$ENV_AWS_ACCESS_KEY_ID" ] && [ -n "$ENV_AWS_SECRET_ACCESS_KEY" ] && \
    [ -n "$ENV_HEROKU_APP_NAME" ] && [ -n "$ENV_HEROKU_RELEASE_VERSION" ]; then
+  echo "-----> ⌛️  Starting Cloudfront upload and invalidation process" 
   echo "-----> ⌛️  Setting env variables"
   # Set env variables for aws cli
   export AWS_ACCESS_KEY_ID="$ENV_AWS_ACCESS_KEY_ID"

--- a/bin/compile
+++ b/bin/compile
@@ -86,15 +86,11 @@ fi
 echo "-----> ⌛️  Cleaning up slug"
 
 rm -rf "$BUILD_DIR/node_modules" \
-  "$BUILD_DIR/plop" \
   "$BUILD_DIR/frontend" \
   "$BUILD_DIR/packages" \
   "$BUILD_DIR/app/javascript" \
   "$BUILD_DIR/.awscli" \
-  "$BUILD_DIR/.heroku/node" \
-  "$BUILD_DIR/.husky" \
-  "$BUILD_DIR/.turbo" \
-  "$BUILD_DIR/.vscode"
+  "$BUILD_DIR/.heroku/node"
 
 echo "-----> ✅  Cleaning up slug successfully"
 

--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,6 @@ ROOT_DIR=$(pwd)
 echo "-----> ⌛️  Building apps..."
 
 cd $BUILD_DIR
-exec yarn install --frozen-lockfile
 exec yarn build:apps
 cd $ROOT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -9,6 +9,13 @@ CACHE_DIR=$2
 ENV_DIR=$3
 ROOT_DIR=$(pwd)
 
+echo "-----> ⌛️  Building frontend"
+
+cd $BUILD_DIR
+yarn build:apps
+cd $ROOT_DIR
+
+echo "-----> ✅  Frontend built successfully"
 
 # Get env variables
 ENV_ROLE_ARN=$(test -f "$ENV_DIR/ROLE_ARN" && cat "$ENV_DIR/ROLE_ARN" || echo "")
@@ -104,8 +111,9 @@ aws cloudfront create-invalidation --distribution-id $ENV_DISTRIBUTION_ID --path
 
 echo "-----> ✅  Invalidated cache successfully"
 
-echo "-----> ⌛️  Prune FE source code"
+echo "-----> ⌛️  Cleaning up slug"
 
-rm -rf "$BUILD_DIR/frontend" "$BUILD_DIR/packages" "$BUILD_DIR/app/javascript"
+yarn clean
+rm -rf "$BUILD_DIR/frontend" "$BUILD_DIR/packages" "$BUILD_DIR/app/javascript" "/app/.awscli"
 
-echo "-----> ✅  Prune FE source code successfully"
+echo "-----> ✅  Cleaning up slug successfully"

--- a/bin/compile
+++ b/bin/compile
@@ -112,7 +112,8 @@ fi
 
 echo "-----> ⌛️  Cleaning up slug"
 
+cd $BUILD_DIR
 yarn clean
-rm -rf "$BUILD_DIR/frontend" "$BUILD_DIR/packages" "$BUILD_DIR/app/javascript" "/app/.awscli"
+rm -rf frontend packages app/javascript /app/.awscli
 
 echo "-----> ✅  Cleaning up slug successfully"

--- a/bin/compile
+++ b/bin/compile
@@ -65,7 +65,7 @@ if [ -n "$ENV_ROLE_ARN" ] && [ -n "$ENV_S3_BUCKET_NAME" ] && [ -n "$ENV_DISTRIBU
   # Invalidate cache
   # We need to invalidate the cache for manifest.json and manifest-assets.json
   # So users get the last hash versioning
-  aws cloudfront create-invalidation --distribution-id "$ENV_DISTRIBUTION_ID" --paths "/vite/manifest.json" "/vite/manifest-assets.json" --no-cli-pager
+  aws cloudfront create-invalidation --distribution-id "$ENV_DISTRIBUTION_ID" --paths "/vite/*manifest.json" "/vite/*manifest-assets.json" --no-cli-pager
 
   echo "-----> ✅  Invalidated cache successfully"
 else

--- a/bin/compile
+++ b/bin/compile
@@ -31,8 +31,8 @@ if [ -n "$ENV_ROLE_ARN" ] && [ -n "$ENV_S3_BUCKET_NAME" ] && [ -n "$ENV_DISTRIBU
    [ -n "$ENV_HEROKU_APP_NAME" ] && [ -n "$ENV_HEROKU_RELEASE_VERSION" ]; then
   echo "-----> ⌛️  Setting env variables"
   # Set env variables for aws cli
-  AWS_ACCESS_KEY_ID="$ENV_AWS_ACCESS_KEY_ID"
-  AWS_SECRET_ACCESS_KEY="$ENV_AWS_SECRET_ACCESS_KEY"
+  export AWS_ACCESS_KEY_ID="$ENV_AWS_ACCESS_KEY_ID"
+  export AWS_SECRET_ACCESS_KEY="$ENV_AWS_SECRET_ACCESS_KEY"
 
   echo "-----> ✅  Env variables set successfully"
 
@@ -44,11 +44,15 @@ if [ -n "$ENV_ROLE_ARN" ] && [ -n "$ENV_S3_BUCKET_NAME" ] && [ -n "$ENV_DISTRIBU
   echo "-----> ✅  Role assumed successfully"
 
   echo "-----> ⌛️  Setting new temporary env variables from assumed role"
+  
+  # Unset env variables for aws cli
+  unset AWS_SECRET_ACCESS_KEY
+  unset AWS_ACCESS_KEY_ID
 
   # Set new temporary env variables for aws cli with permissions from assumed role
-  AWS_ACCESS_KEY_ID="${STS[0]}"
-  AWS_SECRET_ACCESS_KEY="${STS[1]}"
-  AWS_SESSION_TOKEN="${STS[2]}"
+  export AWS_ACCESS_KEY_ID="${STS[0]}"
+  export AWS_SECRET_ACCESS_KEY="${STS[1]}"
+  export AWS_SESSION_TOKEN="${STS[2]}"
 
   echo "-----> ✅  New temp env variables set successfully"
 

--- a/bin/compile
+++ b/bin/compile
@@ -7,6 +7,12 @@ set -e
 BUILD_DIR=$1
 ENV_DIR=$3
 
+echo "-----> ⌛️  Building apps..."
+
+exec yarn build:apps
+
+echo "-----> ✅  Apps built successfully"
+
 # Get env variables
 ENV_ROLE_ARN=$(test -f "$ENV_DIR/ROLE_ARN" && cat "$ENV_DIR/ROLE_ARN" || echo "")
 ENV_S3_BUCKET_NAME=$(test -f "$ENV_DIR/S3_BUCKET_NAME" && cat "$ENV_DIR/S3_BUCKET_NAME" || echo "")
@@ -50,12 +56,6 @@ if [ -z "$ENV_HEROKU_RELEASE_VERSION" ]; then
   echo "-----> ⏭️  Skipping AWS sync. HEROKU_RELEASE_VERSION is not set"
   exit 0
 fi
-
-echo "-----> ⌛️  Building apps..."
-
-exec yarn build:apps
-
-echo "-----> ✅  Apps built successfully"
 
 
 echo "-----> ⌛️  Setting env variables"

--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# `set –e` is used within the Bash to stop execution instantly as a query exits while having a non-zero status. 
+# `set –e` is used within Bash to stop execution instantly as a query exits with a non-zero status.
 # This function is also used when you need to know the error location in the running code
 set -e
 
@@ -10,109 +10,78 @@ ENV_DIR=$3
 ROOT_DIR=$(pwd)
 
 # Get env variables
-ENV_ROLE_ARN=$(test -f "$ENV_DIR/ROLE_ARN" && cat "$ENV_DIR/ROLE_ARN" || echo "")
-ENV_S3_BUCKET_NAME=$(test -f "$ENV_DIR/S3_BUCKET_NAME" && cat "$ENV_DIR/S3_BUCKET_NAME" || echo "")
-ENV_DISTRIBUTION_ID=$(test -f "$ENV_DIR/DISTRIBUTION_ID" && cat "$ENV_DIR/DISTRIBUTION_ID" || echo "")
-ENV_AWS_ACCESS_KEY_ID=$(test -f "$ENV_DIR/AWS_ACCESS_KEY_ID" && cat "$ENV_DIR/AWS_ACCESS_KEY_ID" || echo "")
-ENV_AWS_SECRET_ACCESS_KEY=$(test -f "$ENV_DIR/AWS_SECRET_ACCESS_KEY" && cat "$ENV_DIR/AWS_SECRET_ACCESS_KEY" || echo "")
-ENV_HEROKU_APP_NAME=$(test -f "$ENV_DIR/HEROKU_APP_NAME" && cat "$ENV_DIR/HEROKU_APP_NAME" || echo "")
-ENV_HEROKU_RELEASE_VERSION=$(test -f "$ENV_DIR/HEROKU_RELEASE_VERSION" && cat "$ENV_DIR/HEROKU_RELEASE_VERSION" || date +%s )
-
+ENV_ROLE_ARN=$(cat "$ENV_DIR/ROLE_ARN" 2>/dev/null || true)
+ENV_S3_BUCKET_NAME=$(cat "$ENV_DIR/S3_BUCKET_NAME" 2>/dev/null || true)
+ENV_DISTRIBUTION_ID=$(cat "$ENV_DIR/DISTRIBUTION_ID" 2>/dev/null || true)
+ENV_AWS_ACCESS_KEY_ID=$(cat "$ENV_DIR/AWS_ACCESS_KEY_ID" 2>/dev/null || true)
+ENV_AWS_SECRET_ACCESS_KEY=$(cat "$ENV_DIR/AWS_SECRET_ACCESS_KEY" 2>/dev/null || true)
+ENV_HEROKU_APP_NAME=$(cat "$ENV_DIR/HEROKU_APP_NAME" 2>/dev/null || true)
+ENV_HEROKU_RELEASE_VERSION=$(cat "$ENV_DIR/HEROKU_RELEASE_VERSION" 2>/dev/null || date +%s)
 
 echo "-----> ⌛️  Building frontend"
 
-cd $BUILD_DIR
+cd "$BUILD_DIR"
 yarn build:apps
-cd $ROOT_DIR
+cd "$ROOT_DIR"
 
 echo "-----> ✅  Frontend built successfully"
-
 
 if [ -n "$ENV_ROLE_ARN" ] && [ -n "$ENV_S3_BUCKET_NAME" ] && [ -n "$ENV_DISTRIBUTION_ID" ] && \
    [ -n "$ENV_AWS_ACCESS_KEY_ID" ] && [ -n "$ENV_AWS_SECRET_ACCESS_KEY" ] && \
    [ -n "$ENV_HEROKU_APP_NAME" ] && [ -n "$ENV_HEROKU_RELEASE_VERSION" ]; then
   echo "-----> ⌛️  Setting env variables"
   # Set env variables for aws cli
-  export AWS_ACCESS_KEY_ID="$ENV_AWS_ACCESS_KEY_ID"
-  export AWS_SECRET_ACCESS_KEY="$ENV_AWS_SECRET_ACCESS_KEY"
+  AWS_ACCESS_KEY_ID="$ENV_AWS_ACCESS_KEY_ID"
+  AWS_SECRET_ACCESS_KEY="$ENV_AWS_SECRET_ACCESS_KEY"
 
   echo "-----> ✅  Env variables set successfully"
-
 
   echo "-----> ⌛️  Assuming role"
 
   # Assume role
-  STS=($(aws sts assume-role --role-arn ${ENV_ROLE_ARN} --role-session-name "${ENV_HEROKU_APP_NAME}-${ENV_HEROKU_RELEASE_VERSION}" --duration-seconds 3600 --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text))
+  STS=($(aws sts assume-role --role-arn "${ENV_ROLE_ARN}" --role-session-name "${ENV_HEROKU_APP_NAME}-${ENV_HEROKU_RELEASE_VERSION}" --duration-seconds 3600 --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text))
 
   echo "-----> ✅  Role assumed successfully"
 
-
   echo "-----> ⌛️  Setting new temporary env variables from assumed role"
 
-  # Unset env variables for aws cli
-  unset AWS_SECRET_ACCESS_KEY
-  unset AWS_ACCESS_KEY_ID
-
   # Set new temporary env variables for aws cli with permissions from assumed role
-  export AWS_ACCESS_KEY_ID="${STS[0]}"
-  export AWS_SECRET_ACCESS_KEY="${STS[1]}"
-  export AWS_SESSION_TOKEN="${STS[2]}"
+  AWS_ACCESS_KEY_ID="${STS[0]}"
+  AWS_SECRET_ACCESS_KEY="${STS[1]}"
+  AWS_SESSION_TOKEN="${STS[2]}"
 
   echo "-----> ✅  New temp env variables set successfully"
-
 
   echo "-----> ⌛️  Syncing bucket"
 
   # Sync bucket
   PUBLIC_FOLDER="$BUILD_DIR/public"
-  aws s3 sync $PUBLIC_FOLDER s3://$ENV_S3_BUCKET_NAME --quiet
+  aws s3 sync "$PUBLIC_FOLDER" "s3://$ENV_S3_BUCKET_NAME" --quiet
 
   echo "-----> ✅  Synced bucket successfully"
-
 
   echo "-----> ⌛️  Invalidating cache"
 
   # Invalidate cache
   # We need to invalidate the cache for manifest.json and manifest-assets.json
   # So users get the last hash versioning
-  aws cloudfront create-invalidation --distribution-id $ENV_DISTRIBUTION_ID --paths "/vite/manifest.json" "/vite/manifest-assets.json" --no-cli-pager
+  aws cloudfront create-invalidation --distribution-id "$ENV_DISTRIBUTION_ID" --paths "/vite/manifest.json" "/vite/manifest-assets.json" --no-cli-pager
 
   echo "-----> ✅  Invalidated cache successfully"
 else
-  if [ -z "$ENV_ROLE_ARN" ]; then
-    echo "-----> ⏭️  Skipping AWS sync. ROLE_ARN is not set"
-  fi
-
-  if [ -z "$ENV_S3_BUCKET_NAME" ]; then
-    echo "-----> ⏭️  Skipping AWS sync. S3_BUCKET_NAME is not set"
-  fi
-
-  if [ -z "$ENV_DISTRIBUTION_ID" ]; then
-    echo "-----> ⏭️  Skipping AWS sync. DISTRIBUTION_ID is not set"
-  fi
-
-  if [ -z "$ENV_AWS_ACCESS_KEY_ID" ]; then
-    echo "-----> ⏭️  Skipping AWS sync. AWS_ACCESS_KEY_ID is not set"
-  fi
-
-  if [ -z "$ENV_AWS_SECRET_ACCESS_KEY" ]; then
-    echo "-----> ⏭️  Skipping AWS sync. AWS_SECRET_ACCESS_KEY is not set"
-  fi
-
-  if [ -z "$ENV_HEROKU_APP_NAME" ]; then
-    echo "-----> ⏭️  Skipping AWS sync. HEROKU_APP_NAME is not set"
-  fi
-
-  if [ -z "$ENV_HEROKU_RELEASE_VERSION" ]; then
-    echo "-----> ⏭️  Skipping AWS sync. HEROKU_RELEASE_VERSION is not set"
-  fi
+  echo "-----> ⏭️  Skipping AWS sync. Some required environment variables are not set:"
+  [ -z "$ENV_ROLE_ARN" ] && echo "ROLE_ARN is not set"
+  [ -z "$ENV_S3_BUCKET_NAME" ] && echo "S3_BUCKET_NAME is not set"
+  [ -z "$ENV_DISTRIBUTION_ID" ] && echo "DISTRIBUTION_ID is not set"
+  [ -z "$ENV_AWS_ACCESS_KEY_ID" ] && echo "AWS_ACCESS_KEY_ID is not set"
+  [ -z "$ENV_AWS_SECRET_ACCESS_KEY" ] && echo "AWS_SECRET_ACCESS_KEY is not set"
+  [ -z "$ENV_HEROKU_APP_NAME" ] && echo "HEROKU_APP_NAME is not set"
+  [ -z "$ENV_HEROKU_RELEASE_VERSION" ] && echo "HEROKU_RELEASE_VERSION is not set"
 fi
-
-
 
 echo "-----> ⌛️  Cleaning up slug"
 
-cd $BUILD_DIR
+cd "$BUILD_DIR"
 yarn clean
 rm -rf frontend packages app/javascript .awscli
 

--- a/bin/compile
+++ b/bin/compile
@@ -11,9 +11,14 @@ ROOT_DIR=$(pwd)
 
 cd $CACHE_DIR
 ls
-
 cd $ROOT_DIR
+
 echo "-----> ⌛️  Building apps..."
+
+echo $CACHE_DIR
+
+mkdir -p "$(dirname "$BUILD_DIR/node_modules")"
+mv "$CACHE_DIR/node/cache/node_modules" "$BUILD_DIR/node_modules"
 
 cd $BUILD_DIR
 exec yarn build:apps
@@ -114,6 +119,3 @@ echo "-----> ⌛️  Invalidating cache"
 aws cloudfront create-invalidation --distribution-id $ENV_DISTRIBUTION_ID --paths "/vite/manifest.json" "/vite/manifest-assets.json" --no-cli-pager
 
 echo "-----> ✅  Invalidated cache successfully"
-
-
-https://github.com/oysterhr/oyster-heroku-buildpack.git#Tur-19425/update-oysterherokubuildpack-to-run-yarn-buildapps-before-uploadi

--- a/bin/compile
+++ b/bin/compile
@@ -114,6 +114,6 @@ echo "-----> ⌛️  Cleaning up slug"
 
 cd $BUILD_DIR
 yarn clean
-rm -rf frontend packages app/javascript /app/.awscli
+rm -rf frontend packages app/javascript .awscli
 
 echo "-----> ✅  Cleaning up slug successfully"

--- a/bin/compile
+++ b/bin/compile
@@ -9,14 +9,6 @@ CACHE_DIR=$2
 ENV_DIR=$3
 ROOT_DIR=$(pwd)
 
-echo "-----> ⌛️  Building frontend"
-
-cd $BUILD_DIR
-yarn build:apps
-cd $ROOT_DIR
-
-echo "-----> ✅  Frontend built successfully"
-
 # Get env variables
 ENV_ROLE_ARN=$(test -f "$ENV_DIR/ROLE_ARN" && cat "$ENV_DIR/ROLE_ARN" || echo "")
 ENV_S3_BUCKET_NAME=$(test -f "$ENV_DIR/S3_BUCKET_NAME" && cat "$ENV_DIR/S3_BUCKET_NAME" || echo "")
@@ -26,90 +18,97 @@ ENV_AWS_SECRET_ACCESS_KEY=$(test -f "$ENV_DIR/AWS_SECRET_ACCESS_KEY" && cat "$EN
 ENV_HEROKU_APP_NAME=$(test -f "$ENV_DIR/HEROKU_APP_NAME" && cat "$ENV_DIR/HEROKU_APP_NAME" || echo "")
 ENV_HEROKU_RELEASE_VERSION=$(test -f "$ENV_DIR/HEROKU_RELEASE_VERSION" && cat "$ENV_DIR/HEROKU_RELEASE_VERSION" || date +%s )
 
-if [ -z "$ENV_ROLE_ARN" ]; then
-  echo "-----> ⏭️  Skipping AWS sync. ROLE_ARN is not set"
-  exit 0
+
+echo "-----> ⌛️  Building frontend"
+
+cd $BUILD_DIR
+yarn build:apps
+cd $ROOT_DIR
+
+echo "-----> ✅  Frontend built successfully"
+
+
+if [ -n "$ENV_ROLE_ARN" ] && [ -n "$ENV_S3_BUCKET_NAME" ] && [ -n "$ENV_DISTRIBUTION_ID" ] && \
+   [ -n "$ENV_AWS_ACCESS_KEY_ID" ] && [ -n "$ENV_AWS_SECRET_ACCESS_KEY" ] && \
+   [ -n "$ENV_HEROKU_APP_NAME" ] && [ -n "$ENV_HEROKU_RELEASE_VERSION" ]; then
+  echo "-----> ⌛️  Setting env variables"
+  # Set env variables for aws cli
+  export AWS_ACCESS_KEY_ID="$ENV_AWS_ACCESS_KEY_ID"
+  export AWS_SECRET_ACCESS_KEY="$ENV_AWS_SECRET_ACCESS_KEY"
+
+  echo "-----> ✅  Env variables set successfully"
+
+
+  echo "-----> ⌛️  Assuming role"
+
+  # Assume role
+  STS=($(aws sts assume-role --role-arn ${ENV_ROLE_ARN} --role-session-name "${ENV_HEROKU_APP_NAME}-${ENV_HEROKU_RELEASE_VERSION}" --duration-seconds 3600 --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text))
+
+  echo "-----> ✅  Role assumed successfully"
+
+
+  echo "-----> ⌛️  Setting new temporary env variables from assumed role"
+
+  # Unset env variables for aws cli
+  unset AWS_SECRET_ACCESS_KEY
+  unset AWS_ACCESS_KEY_ID
+
+  # Set new temporary env variables for aws cli with permissions from assumed role
+  export AWS_ACCESS_KEY_ID="${STS[0]}"
+  export AWS_SECRET_ACCESS_KEY="${STS[1]}"
+  export AWS_SESSION_TOKEN="${STS[2]}"
+
+  echo "-----> ✅  New temp env variables set successfully"
+
+
+  echo "-----> ⌛️  Syncing bucket"
+
+  # Sync bucket
+  PUBLIC_FOLDER="$BUILD_DIR/public"
+  aws s3 sync $PUBLIC_FOLDER s3://$ENV_S3_BUCKET_NAME --quiet
+
+  echo "-----> ✅  Synced bucket successfully"
+
+
+  echo "-----> ⌛️  Invalidating cache"
+
+  # Invalidate cache
+  # We need to invalidate the cache for manifest.json and manifest-assets.json
+  # So users get the last hash versioning
+  aws cloudfront create-invalidation --distribution-id $ENV_DISTRIBUTION_ID --paths "/vite/manifest.json" "/vite/manifest-assets.json" --no-cli-pager
+
+  echo "-----> ✅  Invalidated cache successfully"
+else
+  if [ -z "$ENV_ROLE_ARN" ]; then
+    echo "-----> ⏭️  Skipping AWS sync. ROLE_ARN is not set"
+  fi
+
+  if [ -z "$ENV_S3_BUCKET_NAME" ]; then
+    echo "-----> ⏭️  Skipping AWS sync. S3_BUCKET_NAME is not set"
+  fi
+
+  if [ -z "$ENV_DISTRIBUTION_ID" ]; then
+    echo "-----> ⏭️  Skipping AWS sync. DISTRIBUTION_ID is not set"
+  fi
+
+  if [ -z "$ENV_AWS_ACCESS_KEY_ID" ]; then
+    echo "-----> ⏭️  Skipping AWS sync. AWS_ACCESS_KEY_ID is not set"
+  fi
+
+  if [ -z "$ENV_AWS_SECRET_ACCESS_KEY" ]; then
+    echo "-----> ⏭️  Skipping AWS sync. AWS_SECRET_ACCESS_KEY is not set"
+  fi
+
+  if [ -z "$ENV_HEROKU_APP_NAME" ]; then
+    echo "-----> ⏭️  Skipping AWS sync. HEROKU_APP_NAME is not set"
+  fi
+
+  if [ -z "$ENV_HEROKU_RELEASE_VERSION" ]; then
+    echo "-----> ⏭️  Skipping AWS sync. HEROKU_RELEASE_VERSION is not set"
+  fi
 fi
 
-if [ -z "$ENV_S3_BUCKET_NAME" ]; then
-  echo "-----> ⏭️  Skipping AWS sync. S3_BUCKET_NAME is not set"
-  exit 0
-fi
 
-if [ -z "$ENV_DISTRIBUTION_ID" ]; then
-  echo "-----> ⏭️  Skipping AWS sync. DISTRIBUTION_ID is not set"
-  exit 0
-fi
-
-if [ -z "$ENV_AWS_ACCESS_KEY_ID" ]; then
-  echo "-----> ⏭️  Skipping AWS sync. AWS_ACCESS_KEY_ID is not set"
-  exit 0
-fi
-
-if [ -z "$ENV_AWS_SECRET_ACCESS_KEY" ]; then
-  echo "-----> ⏭️  Skipping AWS sync. AWS_SECRET_ACCESS_KEY is not set"
-  exit 0
-fi
-
-if [ -z "$ENV_HEROKU_APP_NAME" ]; then
-  echo "-----> ⏭️  Skipping AWS sync. HEROKU_APP_NAME is not set"
-  exit 0
-fi
-
-if [ -z "$ENV_HEROKU_RELEASE_VERSION" ]; then
-  echo "-----> ⏭️  Skipping AWS sync. HEROKU_RELEASE_VERSION is not set"
-  exit 0
-fi
-
-
-echo "-----> ⌛️  Setting env variables"
-
-# Set env variables for aws cli
-export AWS_ACCESS_KEY_ID="$ENV_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$ENV_AWS_SECRET_ACCESS_KEY"
-
-echo "-----> ✅  Env variables set successfully"
-
-
-echo "-----> ⌛️  Assuming role"
-
-# Assume role
-STS=($(aws sts assume-role --role-arn ${ENV_ROLE_ARN} --role-session-name "${ENV_HEROKU_APP_NAME}-${ENV_HEROKU_RELEASE_VERSION}" --duration-seconds 3600 --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text))
-
-echo "-----> ✅  Role assumed successfully"
-
-
-echo "-----> ⌛️  Setting new temporary env variables from assumed role"
-
-# Unset env variables for aws cli
-unset AWS_SECRET_ACCESS_KEY
-unset AWS_ACCESS_KEY_ID
-
-# Set new temporary env variables for aws cli with permissions from assumed role
-export AWS_ACCESS_KEY_ID="${STS[0]}"
-export AWS_SECRET_ACCESS_KEY="${STS[1]}"
-export AWS_SESSION_TOKEN="${STS[2]}"
-
-echo "-----> ✅  New temp env variables set successfully"
-
-
-echo "-----> ⌛️  Syncing bucket"
-
-# Sync bucket
-PUBLIC_FOLDER="$BUILD_DIR/public"
-aws s3 sync $PUBLIC_FOLDER s3://$ENV_S3_BUCKET_NAME --quiet
-
-echo "-----> ✅  Synced bucket successfully"
-
-
-echo "-----> ⌛️  Invalidating cache"
-
-# Invalidate cache
-# We need to invalidate the cache for manifest.json and manifest-assets.json
-# So users get the last hash versioning
-aws cloudfront create-invalidation --distribution-id $ENV_DISTRIBUTION_ID --paths "/vite/manifest.json" "/vite/manifest-assets.json" --no-cli-pager
-
-echo "-----> ✅  Invalidated cache successfully"
 
 echo "-----> ⌛️  Cleaning up slug"
 

--- a/bin/compile
+++ b/bin/compile
@@ -51,6 +51,12 @@ if [ -z "$ENV_HEROKU_RELEASE_VERSION" ]; then
   exit 0
 fi
 
+echo "-----> ⌛️  Building apps..."
+
+exec yarn build:apps
+
+echo "-----> ✅  Apps built successfully"
+
 
 echo "-----> ⌛️  Setting env variables"
 

--- a/bin/compile
+++ b/bin/compile
@@ -9,18 +9,11 @@ CACHE_DIR=$2
 ENV_DIR=$3
 ROOT_DIR=$(pwd)
 
-cd $CACHE_DIR
-ls
-cd $ROOT_DIR
 
 echo "-----> ⌛️  Building apps..."
 
-echo $CACHE_DIR
-
-mkdir -p "$(dirname "$BUILD_DIR/node_modules")"
-mv "$CACHE_DIR/node/cache/node_modules" "$BUILD_DIR/node_modules"
-
 cd $BUILD_DIR
+exec yarn install --frozen-lockfile
 exec yarn build:apps
 cd $ROOT_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -7,9 +7,13 @@ set -e
 BUILD_DIR=$1
 ENV_DIR=$3
 
+ROOT_DIR=$(pwd)
+
 echo "-----> ⌛️  Building apps..."
 
+cd $BUILD_DIR
 exec yarn build:apps
+cd $ROOT_DIR
 
 echo "-----> ✅  Apps built successfully"
 
@@ -106,3 +110,6 @@ echo "-----> ⌛️  Invalidating cache"
 aws cloudfront create-invalidation --distribution-id $ENV_DISTRIBUTION_ID --paths "/vite/manifest.json" "/vite/manifest-assets.json" --no-cli-pager
 
 echo "-----> ✅  Invalidated cache successfully"
+
+
+https://github.com/oysterhr/oyster-heroku-buildpack.git#Tur-19425/update-oysterherokubuildpack-to-run-yarn-buildapps-before-uploadi

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,8 @@ ROOT_DIR=$(pwd)
 
 echo "-----> ⌛️  Building apps..."
 
-echo "$ENV_DIR/SKIP_NODE_MODULES_CHECK"
+ENV_SKIP_NODE_MODULES_CHECK=$(test -f "$ENV_DIR/SKIP_NODE_MODULES_CHECK" && cat "$ENV_DIR/SKIP_NODE_MODULES_CHECK" || echo "")
+echo "SKIP_NODE_MODULES_CHECK=$ENV_SKIP_NODE_MODULES_CHECK"
 
 cd $BUILD_DIR
 exec yarn build:apps


### PR DESCRIPTION
Support for building applications with Turbo is added.

Code is refactored since from now on, this buildpack will be mandatory for all applications and environments, even if it is not uploaded to S3, as in the case of review apps.

At the end of the process, all code related to the frontend is removed to reduce the slug size.

Successful deploy: https://dashboard.heroku.com/apps/oysterapp-pr-16127/activity/builds/882897b7-39be-4696-a303-9a70f91ba922