### PR TITLE
Skip sourcemaps generation for turbo apps

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,9 +17,12 @@ ENV_AWS_ACCESS_KEY_ID=$(cat "$ENV_DIR/AWS_ACCESS_KEY_ID" 2>/dev/null || true)
 ENV_AWS_SECRET_ACCESS_KEY=$(cat "$ENV_DIR/AWS_SECRET_ACCESS_KEY" 2>/dev/null || true)
 ENV_HEROKU_APP_NAME=$(cat "$ENV_DIR/HEROKU_APP_NAME" 2>/dev/null || true)
 ENV_HEROKU_RELEASE_VERSION=$(cat "$ENV_DIR/HEROKU_RELEASE_VERSION" 2>/dev/null || date +%s)
+ENV_SKIP_SOURCEMAPS_UPLOAD=$(cat "$ENV_DIR/SKIP_SOURCEMAPS_UPLOAD" 2>/dev/null || true)
 
 if [ -f "$BUILD_DIR/node_modules/.bin/turbo" ]; then
   echo "-----> ⌛️  Building frontend"
+
+  export SKIP_SOURCEMAPS_UPLOAD=$ENV_SKIP_SOURCEMAPS_UPLOAD
 
   cd "$BUILD_DIR"
   yarn build:apps:heroku


### PR DESCRIPTION
Heroku doesn't inject environment variables automatically because each environment variable is a file with its value inside.
Each buildpack has to reinject these variables when the bin compile is executed.

In this case, the `SKIP_SOURCEMAPS_UPLOAD` variable is injected to prevent the generation of sourcemaps, which is causing the deployments to fail in the turbo app `Preview`